### PR TITLE
feat: update documentation to enforce use of ```tab for TAB examples and improve note formatting

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,7 @@ You are prolific in writing TAB notation for a 4-string bass guitar with the sta
 
 - When prompted to write bass guitar TAB notation, ensure that you use the standard tuning of E A D G.
 - Use proper TAB formatting to ensure that the notation is clear and easy to read.
+- **ALWAYS use ````tab` language specifier for TAB examples in markdown code blocks** - this is required for semantic markdown and automated testing.
 - When writing a standard scale always use just the octave pattern (8 notes in total)
 - when tasked to write a pentatonic scale include the 5 notes and the octave (6 notes in total)
 - When writing a mode, use the same approach as with standard scales (8 notes in total)
@@ -18,10 +19,9 @@ You are prolific in writing TAB notation for a 4-string bass guitar with the sta
 
 Here is a correct example for C-major:
 
+**Notes:** C, D, E, F, G, A, B, C
 
-```
-The notes are C, D, E, F, G, A, B, C.
-
+```tab
 G|--------------2-4-5--|
 D|--------2-3-5--------|
 A|--3-5----------------|
@@ -30,9 +30,9 @@ E|---------------------|
 
 Here is another correct example for E major:
 
-```
-The notes are E, F#, G#, A, B, C#, D#, E.
+**Notes:** E, F#, G#, A, B, C#, D#, E
 
+```tab
 G|-------------------------|
 D|----------------11-13-14-|
 A|-------11-12-14----------|
@@ -41,17 +41,18 @@ E|-12-14-------------------|
 
 Here is an incorrect example of the E major scale with too many notes:
 
-```
+```tab
 G|----------------11-13-14-|
 D|-------11-13-14----------|
 A|-11-12-14----------------|
 E|-12-14-------------------|
-
-In general avoid open sstrings in the example, so for example when tasked to do a F# dorian scale do this:
-
 ```
-The notes are F#, G#, A, B, C#, D#, E, F#.
 
+In general avoid open strings in the example, so for example when tasked to do a F# dorian scale do this:
+
+**Notes:** F#, G#, A, B, C#, D#, E, F#
+
+```tab
 G|------------------|
 D|------------1-2-4-|
 A|--------2-4-------|
@@ -60,9 +61,9 @@ E|--2-4-5-----------|
 
 Rather than this:
 
-```
-The notes are F#, G#, A, B, C#, D#, E, F#.
+**Notes:** F#, G#, A, B, C#, D#, E, F#
 
+```tab
 G|------------------|
 D|------------1-2-4-|
 A|------0-2-4-------|

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,7 @@ A|-11-12-14----------------|
 E|-12-14-------------------|
 ```
 
-In general avoid open strings in the example, so for example when tasked to do a F# dorian scale do this:
+In general, avoid using open strings in your examples. For instance, when asked to write a F# dorian scale, do this:
 
 **Notes:** F#, G#, A, B, C#, D#, E, F#
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,7 @@ You are prolific in writing TAB notation for a 4-string bass guitar with the sta
 - When prompted to write bass guitar TAB notation, ensure that you use the standard tuning of E A D G.
 - Use proper TAB formatting to ensure that the notation is clear and easy to read.
 - **ALWAYS use ````tab` language specifier for TAB examples in markdown code blocks** - this is required for semantic markdown and automated testing.
+- **Prioritize ergonomic fingering patterns** - when possible, play notes on higher strings at lower frets rather than stretching to high frets on lower strings (e.g., play A on G string fret 2 instead of D string fret 7).
 - When writing a standard scale always use just the octave pattern (8 notes in total)
 - when tasked to write a pentatonic scale include the 5 notes and the octave (6 notes in total)
 - When writing a mode, use the same approach as with standard scales (8 notes in total)

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -21,8 +21,8 @@ Lydian is a major mode that sounds even brighter or more "magical" than a standa
 *   **Formula:** W-W-W-H-W-W-H
 *   **TAB:**
     ```tab
-    G|--------------4-5--|
-    D|--------2-4-5-7----|
+    G|------------2-4-5--|
+    D|--------2-4-5------|
     A|--3-5--------------|
     E|-------------------|
     ```
@@ -49,8 +49,8 @@ To get from Ionian to Mixolydian, we **flatten the 7th degree** (B becomes B♭)
 *   **Formula:** W-W-H-W-W-H-W
 *   **TAB:**
     ```tab
-    G|--------------3-5--|
-    D|--------3-5-7------|
+    G|------------2-3-5--|
+    D|--------3-5--------|
     A|--3-5-7------------|
     E|-------------------|
     ```
@@ -63,8 +63,8 @@ To get from Mixolydian to Dorian, we **flatten the 3rd degree** (E becomes E♭)
 *   **Formula:** W-H-W-W-W-H-W
 *   **TAB:**
     ```tab
-    G|--------------3-5--|
-    D|--------3-5-7------|
+    G|------------2-3-5--|
+    D|--------3-5--------|
     A|--3-5-6------------|
     E|-------------------|
     ```

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -50,8 +50,8 @@ To get from Ionian to Mixolydian, we **flatten the 7th degree** (B becomes B♭)
 *   **TAB:**
     ```tab
     G|------------2-3-5--|
-    D|--------3-5--------|
-    A|--3-5-7------------|
+    D|------2-3-5--------|
+    A|--3-5--------------|
     E|-------------------|
     ```
 
@@ -64,8 +64,8 @@ To get from Mixolydian to Dorian, we **flatten the 3rd degree** (E becomes E♭)
 *   **TAB:**
     ```tab
     G|------------2-3-5--|
-    D|--------3-5--------|
-    A|--3-5-6------------|
+    D|------1-3-5--------|
+    A|--3-5--------------|
     E|-------------------|
     ```
 
@@ -77,10 +77,10 @@ To get from Dorian to Aeolian, we **flatten the 6th degree** (A becomes A♭). T
 *   **Formula:** W-H-W-W-H-W-W
 *   **TAB:**
     ```tab
-    G|--------------3-5--|
-    D|--------3-5-6------|
-    A|--3-5-6------------|
-    E|-------------------|
+    G|----------1-3-5--|
+    D|------1-3-5------|
+    A|--3-5------------|
+    E|-----------------|
     ```
 
 ### 6. C Phrygian
@@ -91,10 +91,10 @@ To get from Aeolian to Phrygian, we **flatten the 2nd degree** (D becomes D♭).
 *   **Formula:** H-W-W-W-H-W-W
 *   **TAB:**
     ```tab
-    G|--------------3-5--|
-    D|--------3-5-6------|
-    A|--3-4-6------------|
-    E|-------------------|
+    G|----------1-3-5--|
+    D|------1-3-5------|
+    A|--3-4------------|
+    E|-----------------|
     ```
     *(Note: The TAB for C Phrygian and C Aeolian can be identical in this position, the difference is theoretical and in the note names).*
 

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -16,25 +16,25 @@ The order of modes from brightest to darkest is:
 ### 1. C Lydian (The Brightest)
 Lydian is a major mode that sounds even brighter or more "magical" than a standard major scale because its **4th degree is raised**.
 
-*   **Notes:** C - D - E - **F♯** - G - A - B
+*   **Notes:** C, D, E, F♯, G, A, B, C
 *   **Change:** F → F♯
 *   **Formula:** W-W-W-H-W-W-H
 *   **TAB:**
-    ```
-    G|-------------4-5--|
-    D|-------2-4-5------|
-    A|-3-5--------------|
-    E|------------------|
+    ```tab
+    G|--------------4-5--|
+    D|--------2-4-5-7----|
+    A|--3-5--------------|
+    E|-------------------|
     ```
 
 ### 2. C Ionian (The Major Scale)
 To get from Lydian to Ionian, we **flatten the 4th degree** (F♯ becomes F). This gives us the familiar, happy sound of the major scale.
 
-*   **Notes:** C - D - E - **F** - G - A - B
+*   **Notes:** C, D, E, F, G, A, B, C
 *   **Change:** None (This is the baseline Major Scale)
 *   **Formula:** W-W-H-W-W-W-H
 *   **TAB:**
-    ```
+    ```tab
     G|--------------2-4-5--|
     D|--------2-3-5--------|
     A|--3-5----------------|
@@ -44,72 +44,72 @@ To get from Lydian to Ionian, we **flatten the 4th degree** (F♯ becomes F). Th
 ### 3. C Mixolydian
 To get from Ionian to Mixolydian, we **flatten the 7th degree** (B becomes B♭). This creates a "bluesy" or "rock" dominant sound.
 
-*   **Notes:** C - D - E - F - G - A - **B♭**
+*   **Notes:** C, D, E, F, G, A, B♭, C
 *   **Change:** B → B♭
 *   **Formula:** W-W-H-W-W-H-W
 *   **TAB:**
-    ```
-    G|-------------2-3-5--|
-    D|-------2-3-5--------|
-    A|-3-5----------------|
-    E|--------------------|
+    ```tab
+    G|--------------3-5--|
+    D|--------3-5-7------|
+    A|--3-5-7------------|
+    E|-------------------|
     ```
 
 ### 4. C Dorian
 To get from Mixolydian to Dorian, we **flatten the 3rd degree** (E becomes E♭). This is our first minor mode, with a "cool" or "jazzy" feel.
 
-*   **Notes:** C - D - **E♭** - F - G - A - **B♭**
+*   **Notes:** C, D, E♭, F, G, A, B♭, C
 *   **Change:** E → E♭, B → B♭
 *   **Formula:** W-H-W-W-W-H-W
 *   **TAB:**
-    ```
-    G|-------------3-5----|
-    D|---------3-5--------|
-    A|---3-5-6------------|
-    E|--------------------|
+    ```tab
+    G|--------------3-5--|
+    D|--------3-5-7------|
+    A|--3-5-6------------|
+    E|-------------------|
     ```
 
 ### 5. C Aeolian (The Natural Minor Scale)
 To get from Dorian to Aeolian, we **flatten the 6th degree** (A becomes A♭). This gives us the standard natural minor scale, with its classic sad or melancholic sound.
 
-*   **Notes:** C - D - **E♭** - F - G - **A♭** - **B♭**
+*   **Notes:** C, D, E♭, F, G, A♭, B♭, C
 *   **Change:** E → E♭, A → A♭, B → B♭
 *   **Formula:** W-H-W-W-H-W-W
 *   **TAB:**
-    ```
-    G|-------------3-5----|
-    D|---------3-4-6------|
-    A|---3-4-6------------|
-    E|--------------------|
+    ```tab
+    G|--------------3-5--|
+    D|--------3-5-6------|
+    A|--3-5-6------------|
+    E|-------------------|
     ```
 
 ### 6. C Phrygian
 To get from Aeolian to Phrygian, we **flatten the 2nd degree** (D becomes D♭). This creates a dark, tense sound, often described as Spanish or Flamenco.
 
-*   **Notes:** C - **D♭** - **E♭** - F - G - **A♭** - **B♭**
+*   **Notes:** C, D♭, E♭, F, G, A♭, B♭, C
 *   **Change:** D → D♭, E → E♭, A → A♭, B → B♭
 *   **Formula:** H-W-W-W-H-W-W
 *   **TAB:**
-    ```
-    G|-------------3-5----|
-    D|---------3-4-6------|
-    A|---3-4-6------------|
-    E|--------------------|
+    ```tab
+    G|--------------3-5--|
+    D|--------3-5-6------|
+    A|--3-4-6------------|
+    E|-------------------|
     ```
     *(Note: The TAB for C Phrygian and C Aeolian can be identical in this position, the difference is theoretical and in the note names).*
 
 ### 7. C Locrian (The Darkest)
 Finally, to get from Phrygian to Locrian, we **flatten the 5th degree** (G becomes G♭). This mode is the darkest and most unstable, making it the least common in composition.
 
-*   **Notes:** C - **D♭** - **E♭** - F - **G♭** - **A♭** - **B♭**
+*   **Notes:** C, D♭, E♭, F, G♭, A♭, B♭, C
 *   **Change:** D → D♭, E → E♭, G → G♭, A → A♭, B → B♭
 *   **Formula:** H-W-W-H-W-W-W
 *   **TAB:**
-    ```
-    G|-------------3-5----|
-    D|---------2-4-5------|
-    A|---3-4-6------------|
-    E|--------------------|
+    ```tab
+    G|----------1-3-5--|
+    D|--------3-4------|
+    A|--3-4-6----------|
+    E|-----------------|
     ```
     *(Note: This TAB is one possible fingering for Locrian)*.
 
@@ -125,12 +125,12 @@ This table summarizes the entire process, showing the single note that changes a
 
 | Mode       | Change from Previous Mode | Resulting Scale (Starting from C) | Key Characteristic vs. Major/Minor |
 | :--------- | :------------------------ | :-------------------------------- | :--------------------------------- |
-| **Lydian** | (Brightest Starting Point)  | C D E **F#** G A B                | Major with a **sharp 4th**         |
-| **Ionian** | Flatten the 4th           | C D E **F** G A B                 | The Major Scale                    |
-| **Mixolydian**| Flatten the 7th           | C D E F G A **B♭**                | Major with a **flat 7th**          |
-| **Dorian** | Flatten the 3rd           | C D **Eb** F G A Bb               | Minor with a **major 6th**         |
-| **Aeolian**| Flatten the 6th           | C D Eb F G **Ab** Bb              | The Natural Minor Scale            |
-| **Phrygian**| Flatten the 2nd           | C **Db** Eb F G Ab Bb             | Minor with a **flat 2nd**          |
-| **Locrian**| Flatten the 5th           | C Db Eb F **Gb** Ab Bb            | Minor with a **flat 2nd & flat 5th** |
+| **Lydian** | (Brightest Starting Point)  | C D E **F#** G A B C                | Major with a **sharp 4th**         |
+| **Ionian** | Flatten the 4th           | C D E **F** G A B C                 | The Major Scale                    |
+| **Mixolydian**| Flatten the 7th           | C D E F G A **B♭** C                | Major with a **flat 7th**          |
+| **Dorian** | Flatten the 3rd           | C D **Eb** F G A Bb C               | Minor with a **major 6th**         |
+| **Aeolian**| Flatten the 6th           | C D Eb F G **Ab** Bb C              | The Natural Minor Scale            |
+| **Phrygian**| Flatten the 2nd           | C **Db** Eb F G Ab Bb C             | Minor with a **flat 2nd**          |
+| **Locrian**| Flatten the 5th           | C Db Eb F **Gb** Ab Bb C            | Minor with a **flat 2nd & flat 5th** |
 
 This sequence is a powerful tool. If you know the fretboard pattern for any mode, you can find any other parallel mode just by moving one note up or down a single fret. It demystifies the modes and turns them into a logical, interconnected system.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -107,8 +107,8 @@ Finally, to get from Phrygian to Locrian, we **flatten the 5th degree** (G becom
 *   **TAB:**
     ```tab
     G|----------1-3-5--|
-    D|--------3-4------|
-    A|--3-4-6----------|
+    D|------1-3-4------|
+    A|--3-4------------|
     E|-----------------|
     ```
     *(Note: This TAB is one possible fingering for Locrian)*.


### PR DESCRIPTION
This pull request updates documentation and tests to standardize the formatting of bass guitar TAB notation examples, ensuring consistency and improving automated validation. The most significant changes include enforcing the use of the ```tab language specifier for code blocks, updating the format of notes and TAB examples in documentation, and enhancing test logic to support both old and new formats.